### PR TITLE
Remove Firewall Config

### DIFF
--- a/aws_lab_setup/roles/common/tasks/RedHat.yml
+++ b/aws_lab_setup/roles/common/tasks/RedHat.yml
@@ -3,11 +3,10 @@
   tags:
     - always
 
-- name: RHEL | Install {{ firewall_name }} and libselinux-python
+- name: RHEL | Install libselinux-python
   yum:
     name:
       - libselinux-python
-      - "{{ firewall_name }}"
     state: present
   register: install_packages
   until: install_packages|success
@@ -24,12 +23,5 @@
   notify:
     - reboot
     - wait for instance
-  tags:
-    - common
-
-- name: RHEL | Stop and disable firewall
-  service:
-    name: "{{ firewall_name }}"
-    state: stopped
   tags:
     - common

--- a/aws_lab_setup/roles/common/vars/RedHat-6.yml
+++ b/aws_lab_setup/roles/common/vars/RedHat-6.yml
@@ -1,2 +1,1 @@
-firewall_name: iptables
 common_ssh_service_name: sshd

--- a/aws_lab_setup/roles/common/vars/RedHat-7.yml
+++ b/aws_lab_setup/roles/common/vars/RedHat-7.yml
@@ -1,2 +1,1 @@
-firewall_name: firewalld
 common_ssh_service_name: sshd


### PR DESCRIPTION
Remove iptables/firewalld config from provisioner. Speeds up provisioning and firewall should also be covered by AWS security groups. 